### PR TITLE
Fix link from uses on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ To get the latest stable version of `arduino-cli` just add this step:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@m1.0.0
+  uses: arduino/setup-arduino-cli@v1.0.0
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@m1.0.0
+  uses: arduino/setup-arduino-cli@v1.0.0
   with:
     version: '0.x'
 ```
@@ -26,7 +26,7 @@ To pin the exact version:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@m1.0.0
+  uses: arduino/setup-arduino-cli@v1.0.0
   with:
     version: '0.5.0'
 ```


### PR DESCRIPTION
The following PR adds a `v` instead of the letter `m` that doesn't work properly on CI on the Tutorial of Usage from the Readme.md