### PR TITLE
Use v1 ref in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ To get the latest stable version of `arduino-cli` just add this step:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@v1.1.1
+  uses: arduino/setup-arduino-cli@v1
 ```
 
 If you want to pin a major or minor version you can use the `.x` wildcard:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@v1.1.1
+  uses: arduino/setup-arduino-cli@v1
   with:
     version: "0.x"
 ```
@@ -26,7 +26,7 @@ To pin the exact version:
 
 ```yaml
 - name: Install Arduino CLI
-  uses: arduino/setup-arduino-cli@v1.1.1
+  uses: arduino/setup-arduino-cli@v1
   with:
     version: "0.5.0"
 ```


### PR DESCRIPTION
The v1 branch will be updated on every release that increments the minor or patch version. Therefore, the use of this ref in workflows will result in the workflow automatically benefiting from ongoing improvements or fixes that don't cause a breaking change.