### PR TITLE
update to node16 (node12 support deprecated)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set Node.js 10.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 10.x
+          node-version: 16.x
 
       - name: npm install
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "box"


### PR DESCRIPTION
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Every user of this action is now getting warnings (not yet errors).  For example:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: arduino/setup-arduino-cli
```

I have verified this small change removes this warning when I point to this PR branch.  Given the simplicity of the fix, I hope that's sufficient. 