### PR TITLE
Providing instructions for self hosted solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ To pin the exact version:
     version: "0.5.0"
 ```
 
+### Self-Hosted Actions
+For actions run through gitea, or using CI/CD nektos/act, this action will fail as github token will be wrong when trying to download arduino-cli. Producing a `::error::Bad credentials` error 
+
+To avoid this action failing, [make a Github Token from github developer settings](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), saving it using a secret variable (example below using `TOKEN_FOR_GITHUB`).
+
+Then add an env variable to the step, called INPUT_TOKEN and have that equal the secret, as shown below
+```yaml
+- name: Setup Arduino CLI
+  uses: arduino/setup-arduino-cli@v1.1.1
+  env:
+    INPUT_TOKEN: ${{ secrets.TOKEN_FOR_GITHUB  }}
+```
+
 ## Examples
 
 [Here][example] there is a good example on how to use the action.
@@ -78,3 +91,5 @@ If you think you found a vulnerability or other security-related bug in this pro
 Thank you!
 
 e-mail contact: security@arduino.cc
+
+


### PR DESCRIPTION
When running this action in gitea, or another CI/CD based off github action, this will produce a `::error::Bad credentials` error. Therefore this can be fixed by setting local environment, INPUT_TOKEN, to a user generated GitHub token key 
![image](https://github.com/arduino/setup-arduino-cli/assets/33794556/cb9d8c00-8d16-49e9-aeb6-63150075def4)
