### PR TITLE
Bump Node version to 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Set Node.js 18.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: npm install
         run: npm install

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: "node16"
+  using: "node18"
   main: "dist/index.js"
 branding:
   icon: "box"


### PR DESCRIPTION
# What
This PR updates the actions using Node 16 to Node 18

# Why
GitHub is deprecating Node 16 for GitHub Actions. Therefore currently workflow runs using this action show the warning:
```Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: arduino/setup-arduino-cli@v1.1.2.```

More information is found on [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

But the test suite uses the [**nock**](https://github.com/nock/nock) library to mock and expectations of the HTTP server, and it is not yet supported in Node 20. See: https://github.com/nock/nock/issues/2466

Node 18 is in [Maintenance LTS](https://github.com/nodejs/Release?tab=readme-ov-file#release-schedule) until 2025-04-30, so it can be useful, at least for a year.

